### PR TITLE
fixes redis key TTL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         run: yarn
 
       - name: Set Up Redis
-        uses: shogo82148/actions-setup-redis@v1.8.0
+        uses: shogo82148/actions-setup-redis@v1.9.2
 
       - name: Run TypeScript
         run: yarn typecheck

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,7 @@ export class RedisRateLimiter extends RateLimiter {
 
   constructor({ client, namespace, ...baseOptions }: RedisRateLimiterOptions) {
     super(baseOptions);
-    this.ttl = millisecondsToTTLSeconds(this.interval);
+    this.ttl = microsecondsToTTLSeconds(this.interval);
     this.client = client;
     this.namespace = namespace;
   }
@@ -285,6 +285,6 @@ export function microsecondsToMilliseconds(microseconds: Microseconds): Millisec
   return Math.ceil(microseconds / 1000);
 }
 
-export function millisecondsToTTLSeconds(milliseconds: Milliseconds): Seconds {
-  return Math.ceil(milliseconds / 1000);
+export function microsecondsToTTLSeconds(microseconds: Microseconds): Seconds {
+  return Math.ceil(microseconds / 1000 / 1000);
 }


### PR DESCRIPTION
The value of the `interval` attribute of the `RateLimiter` class is in microseconds.